### PR TITLE
FIX: ベンチマークの計算を変更

### DIFF
--- a/zipline/data/benchmarks.py
+++ b/zipline/data/benchmarks.py
@@ -12,31 +12,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import pandas as pd
-import requests
+from trading_calendars import get_calendar
 
 
-def get_benchmark_returns(symbol):
-    """
-    Get a Series of benchmark returns from IEX associated with `symbol`.
-    Default is `SPY`.
+def get_benchmark_returns(symbol, first_date, last_date):
+    cal = get_calendar('XTKS')
 
-    Parameters
-    ----------
-    symbol : str
-        Benchmark symbol for which we're getting the returns.
+    dates = cal.sessions_in_range(first_date, last_date)
 
-    The data is provided by IEX (https://iextrading.com/), and we can
-    get up to 5 years worth of data.
-    """
-    r = requests.get(
-        'https://api.iextrading.com/1.0/stock/{}/chart/5y'.format(symbol)
-    )
-    data = r.json()
+    data = pd.DataFrame(0.0, index=dates, columns=['close'])
+    data = data['close']
 
-    df = pd.DataFrame(data)
-
-    df.index = pd.DatetimeIndex(df['date'])
-    df = df['close']
-
-    return df.sort_index().tz_localize('UTC').pct_change(1).iloc[1:]
+    return data.sort_index().iloc[1:]

--- a/zipline/data/loader.py
+++ b/zipline/data/loader.py
@@ -213,7 +213,7 @@ def ensure_benchmark_data(symbol, first_date, last_date, now, trading_day,
     )
 
     try:
-        data = get_benchmark_returns(symbol)
+        data = get_benchmark_returns(symbol, first_date, last_date)
         data.to_csv(get_data_filepath(filename, environ))
     except (OSError, IOError, HTTPError):
         logger.exception('Failed to cache the new benchmark returns')


### PR DESCRIPTION
ベンチマークが、APIに繋いで計算しようとしている。
ただ、該当のAPIは動かなくなっているので、処理を変更。